### PR TITLE
Create virtual environment before installing requirements with `uv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project provides comprehensive performance benchmarks for Python 3.14, meas
 pip install -r requirements.txt
 
 # Using uv (faster)
-uv pip install -r requirements.txt
+uv venv && uv pip install -r requirements.txt
 ```
 
 ### Optional: MongoDB (for database benchmarks)


### PR DESCRIPTION
`uv` complains about not having a virtual env when you do `uv pip install`, so this just adds that step. Could also be:

```bash
uv venv
uv pip install -r requirements.txt
```