### PR TITLE
Enable `uvloop` for `granian`

### DIFF
--- a/code/web_frameworks/benchmark_servers.py
+++ b/code/web_frameworks/benchmark_servers.py
@@ -80,8 +80,8 @@ def get_granian_command(server: ServerConfig, port: int, workers: int) -> list[s
         '--workers',
         str(workers),
         '--no-ws',  # Disable websockets for simpler benchmarking
-        # '--loop',
-        # 'uvloop',
+        '--loop',
+        'uvloop',
         server.module,
     ]
 


### PR DESCRIPTION
My understanding is that `uvloop` is the most performant way to run ASGI for `granian`. I enabled it on my local and the benchmark ran fine, but maybe you ran into issues with it?